### PR TITLE
feat: update cmake required version for xkbcommon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ pkg_check_modules(
   deps
   REQUIRED
   IMPORTED_TARGET
-  xkbcommon
+  xkbcommon>=1.11.0
   uuid
   wayland-server>=1.22.90
   wayland-protocols>=1.45


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR updates the dependency needed for xbkcommon.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The flag `XKB_KEYMAP_FORMAT_TEXT_V2` and the function `xkb_keymap_new_from_names2` were introduced in version 1.11.0 of the package `libxkbcommon`. Some distros (in particular Fedora 42) still have older versions in their mainline repos, so this check blocks anyone from compiling the package and having an error due to invalid functions for library mismatch.

#### Is it ready for merging, or does it need work?

Should be ready to merge
